### PR TITLE
Return all statistic tables from team page

### DIFF
--- a/src/statistics/html-parser/team-parser/team-parser.spec.ts
+++ b/src/statistics/html-parser/team-parser/team-parser.spec.ts
@@ -6,16 +6,18 @@ describe('html-parser', () => {
   describe('team data', () => {
     it('should return all team data from html page with correct units and values', () => {
       const result = parseKilometrikisaTeamPageStatistics(teamPageHtmlMock());
-      expect(result).toEqual({
-        series: TeamSeries.SMALL,
-        seriesPlacement: null,
-        distancePerPerson: 300,
-        totalDistance: 1234,
-        daysPerPerson: 26,
-        totalDays: 358,
-        savedGas: 256,
-        savedCO2: 98,
-      });
+      expect(result).toEqual([
+        {
+          series: TeamSeries.SMALL,
+          seriesPlacement: null,
+          distancePerPerson: 300,
+          totalDistance: 1234,
+          daysPerPerson: 26,
+          totalDays: 358,
+          savedGas: 256,
+          savedCO2: 98,
+        },
+      ]);
     });
 
     it('should throw an error if the parsing failed', () => {

--- a/src/statistics/statistics.production.spec.ts
+++ b/src/statistics/statistics.production.spec.ts
@@ -10,18 +10,20 @@ describe('statistics', () => {
 
     let credentials: SessionCredentials;
 
-    beforeAll(async () => {
-      credentials = await login({ username, password });
+    describe('team member statistics', () => {
+      beforeAll(async () => {
+        credentials = await login({ username, password });
+      });
+
+      it('should fetch team member statistics', async () => {
+        const results = await getTeamMemberStatistics(teamSlug, contestSlug, credentials);
+        expect(results.distanceStatistics.length).toBeGreaterThan(0);
+      });
     });
 
     it('should fetch team statistics', async () => {
-      const results = await getTeamStatistics('vincit-forza');
-      expect(results).not.toBeNull();
-    });
-
-    it('should fetch team member statistics', async () => {
-      const results = await getTeamMemberStatistics(teamSlug, contestSlug, credentials);
-      expect(results.distanceStatistics.length).toBeGreaterThan(0);
+      const results = await getTeamStatistics('elomatic');
+      expect(results.length).toBe(2);
     });
   });
 });

--- a/src/statistics/statistics.ts
+++ b/src/statistics/statistics.ts
@@ -9,7 +9,10 @@ const kilometrikisaBaseUrl = 'https://www.kilometrikisa.fi';
 const kilometrikisaTeamPageBaseUrl = `${kilometrikisaBaseUrl}/teams/`;
 
 /**
- * Fetch team statistics from Kilometrikisa. Does not need authentication.
+ * Fetch team statistics from Kilometrikisa. Does not need authentication. Returns all statistic tables
+ * as separate data-objects. One team page might contain two statistic tables. One for regular cycling and one for
+ * electric bikes.
+ *
  * @param teamSlug  The name of the team in "slugified" format. You can pick the value from team page url on the kilometrikisa website.
  */
 export async function getTeamStatistics(teamSlug: string) {


### PR DESCRIPTION
If team has both ebike and regular cycling statistics, return both of them
as separate data-objects.