### PR TITLE
Add simple rate limiting to the client

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,3 +2,4 @@ export KILOMETRIKISA_USERNAME=EssiEsimerkki
 export KILOMETRIKISA_PASSWORD=hunter2
 export KILOMETRIKISA_TEAM_SLUG=kisa-tiimi
 export KILOMETRIKISA_CONTEST_SLUG=kilometrikisa-2021
+export RATE_LIMITER=true

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
+  testTimeout: 10000,
   testEnvironment: 'jest-environment-node',
   globals: {
     'ts-jest': {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
+    "watch": "tsc --watch --project tsconfig.build.json",
     "test": "jest --testPathIgnorePatterns .production.spec.ts",
     "test:coverage": "npm run test -- --coverage",
     "test:production": "export $(cat .env | xargs) && jest src/**/*.production.spec.ts",

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,11 @@ team slug can be found from public team page's url: `https://www.kilometrikisa.f
 Contest slug can be found from the team page url when logged in. Usually it is in form of `kilometrikisa-2022` etc.
 For more check [API Reference](https://github.com/Tumetsu/kilometrikisa-client/wiki/Exports)
 
+### Rate limiting
+To prevent accidentally making too many requests too fast, by default the client rate limits requests
+to rather conservative 10 requests / second. If you know what you are doing, you can reconfigure the 
+rate limits by using [`configureRateLimit` api](https://github.com/Tumetsu/kilometrikisa-client/wiki/Exports#configureratelimit).
+
 
 ## Development
 

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,1 +1,2 @@
 import './src/utils/jest-custom-matchers'; // This module adds custom matchers to the Jest expect
+import './src/utils/jest-fixtures';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { login, LoginCredentials, SessionCredentials } from './auth/auth';
 import { KilometrikisaSession } from './KilometrikisaSession';
+import { setupRateLimiter } from './rate-limit/rate-limit';
 
 export { KilometrikisaErrorCode, KilometrikisaError } from './utils/error-handling';
 export { getTeamStatistics, getTeams } from './statistics/statistics';
@@ -10,6 +11,7 @@ export {
   getAllContestUrls,
 } from './contest/contest';
 export { KilometrikisaSession } from './KilometrikisaSession';
+export { configureRateLimit } from './rate-limit/rate-limit';
 
 // Interfaces
 export { LoginCredentials, SessionCredentials } from './auth/auth';
@@ -21,6 +23,8 @@ export {
 export { Team, Pagination } from './statistics/html-parser/team-list-parser/team-list-parser';
 export { TeamListSortCriteria, TeamSortOptions } from './statistics/statistics';
 export { Contest } from './contest/contest';
+
+setupRateLimiter();
 
 /**
  * Get a client class with API-methods to access Kilometrikisa features which require authentication with user account.

--- a/src/rate-limit/rate-limit.spec.ts
+++ b/src/rate-limit/rate-limit.spec.ts
@@ -1,0 +1,72 @@
+import {
+  configureRateLimit,
+  requestFullfilledInterceptor,
+  requestQueue,
+  setupRateLimiter,
+} from './rate-limit';
+
+function times(n: number, call: (index: number) => void) {
+  return Array(n)
+    .fill('1')
+    .map((item: string, i: number) => call(i));
+}
+
+function requestFullfilled(data: number) {
+  requestFullfilledInterceptor({ data });
+}
+
+describe('rate limiting', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    setupRateLimiter();
+  });
+
+  afterEach(() => {
+    // Reset rate limiter back to defaults
+    configureRateLimit(10, 1000);
+  });
+
+  describe('with axios interceptors', () => {
+    it('should at maximum execute ~10 requests at once and wait 1s to send next batch from queue', async () => {
+      configureRateLimit(10, 1000);
+
+      expect(requestQueue.length).toBe(0);
+
+      // Simulate intercepting 100 requests
+      times(99, requestFullfilled);
+
+      expect(requestQueue.length).toBe(99);
+
+      // Add 20 more
+      times(20, requestFullfilled);
+
+      expect(requestQueue.length).toBe(119);
+
+      // Clear from the queue 10
+      jest.advanceTimersByTime(1001);
+
+      // There is still 99 request in queue waiting
+      expect(requestQueue.length).toBe(99);
+
+      jest.advanceTimersByTime(1001);
+
+      expect(requestQueue.length).toBe(89);
+
+      // Clear from the queue rest
+      jest.advanceTimersByTime(9000);
+
+      expect(requestQueue.length).toBe(0);
+    });
+
+    it('should execute all requests at once if rate limiting is disabled', async () => {
+      configureRateLimit(0);
+
+      expect(requestQueue.length).toBe(0);
+
+      // Simulate intercepting 100 requests
+      times(99, requestFullfilled);
+
+      expect(requestQueue.length).toBe(0);
+    });
+  });
+});

--- a/src/rate-limit/rate-limit.ts
+++ b/src/rate-limit/rate-limit.ts
@@ -1,0 +1,105 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+let _batchTimeIntervalMs = 1000;
+let _maxRequestsPerInterval = 10;
+let currentRequests = 0;
+let rateLimitEnabled = true;
+let queueTimeout: NodeJS.Timeout | null = null;
+
+/**
+ * Export request queue for tests.
+ */
+export const requestQueue: (() => void)[] = [];
+
+/**
+ * Configure rate limiting values. By default the client executes at maximum 10 requests / second.
+ *
+ * If either value is set to 0, rate limiting is disabled. Please be considerate
+ * to the service provider if lowering these values from defaults!
+ * @param maxRequestsPerInterval
+ * @param timeIntervalMs
+ */
+export function configureRateLimit(maxRequestsPerInterval = 10, timeIntervalMs = 1000) {
+  rateLimitEnabled = timeIntervalMs > 0 && maxRequestsPerInterval > 0;
+  _batchTimeIntervalMs = timeIntervalMs;
+  _maxRequestsPerInterval = maxRequestsPerInterval;
+}
+
+/**
+ * Setup rate limiting to Axios interceptors.
+ */
+export function setupRateLimiter() {
+  axios.interceptors.request.use(requestFullfilledInterceptor);
+}
+
+/**
+ * Begin the request queue handler loop.
+ */
+function startRequestQueue() {
+  if (!queueTimeout) {
+    queueTimeout = setTimeout(executeRequestBatch, 0);
+  }
+}
+
+/**
+ * Stop the request timeout. Exported so that in tests the rate limit can be cleared
+ * properly.
+ */
+export function stopRequestQueue() {
+  if (queueTimeout) {
+    clearTimeout(queueTimeout);
+    queueTimeout = null;
+  }
+}
+
+/**
+ * Pick request promises from the queue and execute them immediately.
+ * Recursively setups a new timeout unless there is no requests in queue and
+ * none in the current "time slot". This way the timeout loop does not call itself infinitely
+ * for no reason. This is nice since active timeouts prevent program from exiting naturally.
+ */
+function executeRequestBatch() {
+  const nextBatch = requestQueue.splice(0, _maxRequestsPerInterval);
+  nextBatch.forEach(r => r());
+  currentRequests += nextBatch.length;
+
+  if (currentRequests > 0) {
+    queueTimeout = setTimeout(() => {
+      currentRequests = 0;
+      executeRequestBatch();
+    }, _batchTimeIntervalMs);
+  } else if (queueTimeout) {
+    stopRequestQueue();
+  }
+}
+
+/**
+ * Utility to force the awaiting async-function to wait for its turn until it is let to continue
+ * by the timeout.
+ */
+async function waitInQueue() {
+  startRequestQueue();
+  return new Promise(resolve => {
+    requestQueue.push(() => {
+      resolve(true);
+    });
+  });
+}
+
+/**
+ * An Axios interceptor which forces the request to wait its turn in queue until it is
+ * actually executed.
+ *
+ * @param config
+ */
+export async function requestFullfilledInterceptor(config: AxiosRequestConfig) {
+  if (rateLimitEnabled) {
+    await waitInQueue();
+  }
+  return config;
+}
+
+// Clear timeout on exit
+[`exit`, `SIGINT`, `SIGUSR1`, `SIGUSR2`, `uncaughtException`, `SIGTERM`].forEach(eventType => {
+  process.on(eventType, stopRequestQueue.bind(null, eventType));
+});

--- a/src/utils/jest-fixtures.ts
+++ b/src/utils/jest-fixtures.ts
@@ -1,0 +1,18 @@
+import { setupRateLimiter, stopRequestQueue } from '../rate-limit/rate-limit';
+
+beforeAll(() => {
+  // Run local tests without rate limiter unless explicitly setup in tests.
+  // Use rate limiter in production tests
+  if (process.env.RATE_LIMITER) {
+    console.log('Setup rate limiting for tests');
+    setupRateLimiter();
+  }
+});
+
+/**
+ * Run after all tests have ran.
+ */
+afterAll(() => {
+  // Stop running intervals to prevent Jest from complaining about that
+  stopRequestQueue();
+});


### PR DESCRIPTION
To prevent accidentally making too many requests. For now limited to
10 requests/second.